### PR TITLE
Fix "invalid escape sequence \l" warning

### DIFF
--- a/pygit2/_build.py
+++ b/pygit2/_build.py
@@ -51,7 +51,7 @@ def _get_libgit2_path():
 
     # Default
     if os.name == 'nt':
-        return '%s\libgit2' % getenv("ProgramFiles")
+        return r'%s\libgit2' % getenv("ProgramFiles")
     return '/usr/local'
 
 


### PR DESCRIPTION
With warning levels cranked up in Python 3.6 we get the following:

```
>>> import pygit2
<path>/pygit2/_build.py:54: DeprecationWarning:   File "<stdin>", line 1, in <module>

<stacktrace>

invalid escape sequence \l
  return '%s\libgit2' % getenv("ProgramFiles")
```